### PR TITLE
Reducing the APIs menu

### DIFF
--- a/api/API_index/Plugins-API.rst
+++ b/api/API_index/Plugins-API.rst
@@ -1,0 +1,48 @@
+.. figure:: /docs/images/scipion_logo.gif
+   :width: 250
+   :alt: scipion logo
+
+.. _Plugins-API:
+
+Plugins API
+===========
+
+Find below the API documentation for all Scipion plugins
+
+.. toctree::
+    :maxdepth: 1
+
+   api/appion/appion
+   api/atomstructutils/atomstructutils
+   api/atsas/atsas
+   api/bamfordlab/bamfordlab
+   api/bsoft/bsoft
+   api/ccp4/ccp4
+   api/chimera/chimera
+   api/cistem/cistem
+   api/cryoef/cryoef
+   api/cryosparc2/cryosparc2
+   api/deepfinder/deepfinder
+   api/dynamo/dynamo
+   api/eman2/eman2
+   api/emxlib/emxlib
+   api/fsc3d/fsc3d
+   api/gautomatch/gautomatch
+   api/gctf/gctf
+   api/imod/imod
+   api/localrec/localrec
+   api/locscale/locscale
+   api/motioncorr/motioncorr
+   api/novactf/novactf
+   api/nysbc/nysbc
+   api/phenix/phenix
+   api/relion/relion
+   api/resmap/resmap
+   api/sphire/sphire
+   api/spider/spider
+   api/tomo/tomo
+   api/tomoj/tomoj
+   api/topaz/topaz
+   api/xmipp2/xmipp2
+   api/xmipp3/xmipp3
+   api/xmipptomo/xmipptomo

--- a/api/API_index/Scipion-API.rst
+++ b/api/API_index/Scipion-API.rst
@@ -1,0 +1,17 @@
+.. figure:: /docs/images/scipion_logo.gif
+   :width: 250
+   :alt: scipion logo
+
+.. _Scipion-API:
+
+Scipion API
+===========
+
+Find below the API documentation for the Scipion core
+
+.. toctree::
+    :maxdepth: 1
+
+    api/scipion/scipion
+    api/pyworkflow/pyworkflow
+    api/pwem/pwem

--- a/docs/scipion-modes/scipion-configuration.rst
+++ b/docs/scipion-modes/scipion-configuration.rst
@@ -64,17 +64,22 @@ are set to a certain path, determining a certain version. On the other hand, the
 variables that are not defined here will remain by default and a plugin update will
 eventually update them.
 
-Run ``./scipion3 config -p pluginModule`` to see the plugin-variables associated
-to a certain plugin. Note that ``pluginModule`` is the module name of the plugin
+Run
+
+::
+
+    ./scipion3 config -p pluginModule
+
+to see the plugin-variables associated
+to a certain plugin. Note that ``pluginModule`` is the module name of the plugin,
+check :ref:`the plugin's modules list <api/API_index/Plugins-API>`
 (e.g. ``xmipp3`` is the module of the ``scipion-em-xmipp`` plugin)
 
-.. comment::
-    Consider to add a correspondance table between plugin-name and module-name
-
-Once ``config/scipion.conf`` is changed, run ``./scipion3 config`` again to make some checks.
+Once ``config/scipion.conf`` is changed, run ``./scipion3 config`` again
+to make some checks.
 
 If you have configuration files from previous installations, you may
-want to use this instead:
+want to use this instead (consider to make a backup of you config files before):
 
 ::
 

--- a/index.rst
+++ b/index.rst
@@ -56,44 +56,8 @@ later on.
    :titlesonly:
    :caption: API Documentation
 
-   api/appion/appion
-   api/atomstructutils/atomstructutils
-   api/atsas/atsas
-   api/bamfordlab/bamfordlab
-   api/bsoft/bsoft
-   api/ccp4/ccp4
-   api/chimera/chimera
-   api/cistem/cistem
-   api/cryoef/cryoef
-   api/cryosparc2/cryosparc2
-   api/deepfinder/deepfinder
-   api/dynamo/dynamo
-   api/eman2/eman2
-   api/emxlib/emxlib
-   api/fsc3d/fsc3d
-   api/gautomatch/gautomatch
-   api/gctf/gctf
-   api/imod/imod
-   api/localrec/localrec
-   api/locscale/locscale
-   api/motioncorr/motioncorr
-   api/novactf/novactf
-   api/nysbc/nysbc
-   api/phenix/phenix
-   api/pyworkflow/pyworkflow
-   api/pwem/pwem
-   api/relion/relion
-   api/resmap/resmap
-   api/scipion/scipion
-   api/sphire/sphire
-   api/spider/spider
-   api/tomo/tomo
-   api/tomoj/tomoj
-   api/topaz/topaz
-   api/xmipp2/xmipp2
-   api/xmipp3/xmipp3
-   api/xmipptomo/xmipptomo
-
+   api/API_index/Scipion-API
+   api/API_index/Plugins-API
 
 
 .. _contact:


### PR DESCRIPTION
I think that the APIs menu is huge and this makes that left menu becomes not friendly.

In this PR, I propose to separate Core than Plugin API, reducing the menu items and making searches easy, even we could consider to separate SPA from TOMO in a near future.